### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 ## Official release of ACAT v1.00.0 now available [here] (https://github.com/01org/acat/releases)
 
 
-##Introduction
+## Introduction
 Assistive Context-Aware Toolkit (ACAT) is an open source platform developed at Intel Labs to enable people with motor neuron diseases and other disabilities to have full access to the capabilities and applications of their computers through very constrained interfaces suitable for their condition.  More specifically, ACAT enables users to easily communicate with others through keyboard simulation, word prediction and speech synthesis. Users can perform a range of tasks such as editing, managing documents, navigating the Web and accessing emails. 
 
 ACAT was originally developed by researchers at Intel Labs for Professor Stephen Hawking, through a very iterative design process over the course of three years. Professor Hawking was instrumental to the design process and was a key contributor to the project design and validation. After Intel deployed the system to Professor Hawking, we turned our attention to the larger community and continued to make ACAT more configurable to support a larger set of users with different conditions.
@@ -10,12 +10,12 @@ Our hope is that, by open sourcing this configurable platform, developers will c
 
 ACAT is written in C# using Microsoft Visual Studio 2012 and .NET 4.5 and runs on Microsoft Windows 7 or later. Word prediction functionality is powered by [Presage](http://presage.sourceforge.net/), an intelligent predictive text engine created by Matteo Vescovi. 
 
-##Project Website
+## Project Website
 Click [here](http://01.org/acat) for the ACAT project website.
 Documentation can be found [here](https://01.org/acat/documentation-list)
 
-##Licensing
+## Licensing
 ACAT is distributed under the Apache License, Version 2.0.  
 
-##Who It's For
+## Who It's For
 ACAT is useful for Microsoft Windows developers who are interested in developing assistive technologies to people with ALS or similar disabilities. Also for researchers who are working on new user interfaces, new sensing modalities or word prediction and wanting to explore these innovations in the this community.


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
