### PR TITLE
Refactor assembly versioning and properties across multiple projects

### DIFF
--- a/src/ACATResources/Properties/AssemblyInfo.cs
+++ b/src/ACATResources/Properties/AssemblyInfo.cs
@@ -22,16 +22,3 @@ using System.Runtime.InteropServices;
 
 // The following GUID is for the ID of the typelib if this project is exposed to COM
 [assembly: Guid("1afb947e-d5fa-4e8d-b218-9d7aef32460f")]
-
-// Version information for an assembly consists of the following four values:
-//
-//      Major Version
-//      Minor Version 
-//      Build Number
-//      Revision
-//
-// You can specify all the values or you can default the Build and Revision Numbers 
-// by using the '*' as shown below:
-// [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("3.13")]
-[assembly: AssemblyFileVersion("3.13")]

--- a/src/Applications/ACATConfig/Properties/AssemblyInfo.cs
+++ b/src/Applications/ACATConfig/Properties/AssemblyInfo.cs
@@ -22,17 +22,3 @@ using System.Runtime.InteropServices;
 
 // The following GUID is for the ID of the typelib if this project is exposed to COM
 [assembly: Guid("d353daaf-58a3-423c-b3d9-8c9638c043e7")]
-
-// Version information for an assembly consists of the following four values:
-//
-//      Major Version
-//      Minor Version 
-//      Build Number
-//      Revision
-//
-// You can specify all the values or you can default the Build and Revision Numbers 
-// by using the '*' as shown below:
-// [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("3.13")]
-[assembly: AssemblyFileVersion("3.13")]
-

--- a/src/Applications/ACATTalk/Properties/AssemblyInfo.cs
+++ b/src/Applications/ACATTalk/Properties/AssemblyInfo.cs
@@ -22,17 +22,3 @@ using System.Runtime.InteropServices;
 
 // The following GUID is for the ID of the typelib if this project is exposed to COM
 [assembly: Guid("2b16cd9f-5e6e-4beb-b5d2-79e0edf6d231")]
-
-// Version information for an assembly consists of the following four values:
-//
-//      Major Version
-//      Minor Version 
-//      Build Number
-//      Revision
-//
-// You can specify all the values or you can default the Build and Revision Numbers 
-// by using the '*' as shown below:
-// [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("3.13")]
-[assembly: AssemblyFileVersion("3.13")]
-

--- a/src/Applications/ACATWatch/Properties/AssemblyInfo.cs
+++ b/src/Applications/ACATWatch/Properties/AssemblyInfo.cs
@@ -21,16 +21,3 @@ using System.Runtime.InteropServices;
 
 // The following GUID is for the ID of the typelib if this project is exposed to COM
 [assembly: Guid("e47223ce-3a77-47d1-9729-edf05f97d4f1")]
-
-// Version information for an assembly consists of the following four values:
-//
-//      Major Version
-//      Minor Version 
-//      Build Number
-//      Revision
-//
-// You can specify all the values or you can default the Build and Revision Numbers 
-// by using the '*' as shown below:
-// [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("3.13")]
-[assembly: AssemblyFileVersion("3.13")]

--- a/src/Applications/AppCommon/Properties/AssemblyInfo.cs
+++ b/src/Applications/AppCommon/Properties/AssemblyInfo.cs
@@ -22,16 +22,3 @@ using System.Runtime.InteropServices;
 
 // The following GUID is for the ID of the typelib if this project is exposed to COM
 [assembly: Guid("96b00334-d46e-4257-b5d8-c9e059e08183")]
-
-// Version information for an assembly consists of the following four values:
-//
-//      Major Version
-//      Minor Version 
-//      Build Number
-//      Revision
-//
-// You can specify all the values or you can default the Build and Revision Numbers 
-// by using the '*' as shown below:
-// [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("3.10")]
-[assembly: AssemblyFileVersion("3.10")]

--- a/src/Applications/ConvAssistTerminate/ConvAssistTerminate.csproj
+++ b/src/Applications/ConvAssistTerminate/ConvAssistTerminate.csproj
@@ -11,7 +11,7 @@
     <TargetFrameworkVersion>v4.8.1</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
-    <Deterministic>true</Deterministic>
+    <Deterministic>false</Deterministic>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <PlatformTarget>AnyCPU</PlatformTarget>

--- a/src/Applications/ConvAssistTerminate/Properties/AssemblyInfo.cs
+++ b/src/Applications/ConvAssistTerminate/Properties/AssemblyInfo.cs
@@ -21,16 +21,3 @@ using System.Runtime.InteropServices;
 
 // The following GUID is for the ID of the typelib if this project is exposed to COM
 [assembly: Guid("edb861ec-18cb-4578-8dfc-36658124f70c")]
-
-// Version information for an assembly consists of the following four values:
-//
-//      Major Version
-//      Minor Version
-//      Build Number
-//      Revision
-//
-// You can specify all the values or you can default the Build and Revision Numbers
-// by using the '*' as shown below:
-// [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.0.0.0")]
-[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -1,0 +1,23 @@
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <VersionPrefix>3.13.0</VersionPrefix>
+    <AssemblyVersion>$(VersionPrefix).*</AssemblyVersion>
+    <FileVersion>$(VersionPrefix)</FileVersion>
+    <InformationalVersion>$(VersionPrefix)</InformationalVersion>
+  </PropertyGroup>
+
+  <Target Name="InjectAssemblyVersion" BeforeTargets="BeforeCompile">
+    <WriteLinesToFile
+      File="$(IntermediateOutputPath)AutoAssemblyVersion.cs"
+      Lines='
+using System.Reflection%3B
+[assembly: AssemblyVersion("$(AssemblyVersion)")]
+[assembly: AssemblyFileVersion("$(FileVersion)")]
+[assembly: AssemblyInformationalVersion("$(InformationalVersion)")];
+'
+      Overwrite="true" />
+    <ItemGroup>
+      <Compile Include="$(IntermediateOutputPath)AutoAssemblyVersion.cs" />
+    </ItemGroup>
+  </Target>
+</Project>

--- a/src/Extensions/BCI/Actuators/BCIActuator/BCIActuator.csproj
+++ b/src/Extensions/BCI/Actuators/BCIActuator/BCIActuator.csproj
@@ -11,7 +11,7 @@
     <AssemblyName>BCIActuator</AssemblyName>
     <TargetFrameworkVersion>v4.8.1</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
-    <Deterministic>true</Deterministic>
+    <Deterministic>false</Deterministic>
     <TargetFrameworkProfile />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/src/Extensions/BCI/Actuators/BCIActuator/Properties/AssemblyInfo.cs
+++ b/src/Extensions/BCI/Actuators/BCIActuator/Properties/AssemblyInfo.cs
@@ -21,16 +21,3 @@ using System.Runtime.InteropServices;
 
 // The following GUID is for the ID of the typelib if this project is exposed to COM
 [assembly: Guid("acd93bc0-e644-40be-9749-d0665a90e43c")]
-
-// Version information for an assembly consists of the following four values:
-//
-//      Major Version
-//      Minor Version
-//      Build Number
-//      Revision
-//
-// You can specify all the values or you can default the Build and Revision Numbers
-// by using the '*' as shown below:
-// [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.0.0.0")]
-[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/src/Extensions/BCI/Actuators/EEGDataAcquisition/EEGDataAcquisition.csproj
+++ b/src/Extensions/BCI/Actuators/EEGDataAcquisition/EEGDataAcquisition.csproj
@@ -11,7 +11,7 @@
     <AssemblyName>EEGDataAcquisition</AssemblyName>
     <TargetFrameworkVersion>v4.8.1</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
-    <Deterministic>true</Deterministic>
+    <Deterministic>false</Deterministic>
     <TargetFrameworkProfile />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/src/Extensions/BCI/Actuators/EEGDataAcquisition/Properties/AssemblyInfo.cs
+++ b/src/Extensions/BCI/Actuators/EEGDataAcquisition/Properties/AssemblyInfo.cs
@@ -21,16 +21,3 @@ using System.Runtime.InteropServices;
 
 // The following GUID is for the ID of the typelib if this project is exposed to COM
 [assembly: Guid("16522c79-a205-4b58-a34e-b64202080008")]
-
-// Version information for an assembly consists of the following four values:
-//
-//      Major Version
-//      Minor Version
-//      Build Number
-//      Revision
-//
-// You can specify all the values or you can default the Build and Revision Numbers
-// by using the '*' as shown below:
-// [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.0.0.0")]
-[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/src/Extensions/BCI/Actuators/EEGProcessing/EEGProcessing.csproj
+++ b/src/Extensions/BCI/Actuators/EEGProcessing/EEGProcessing.csproj
@@ -11,7 +11,7 @@
     <AssemblyName>EEGProcessing</AssemblyName>
     <TargetFrameworkVersion>v4.8.1</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
-    <Deterministic>true</Deterministic>
+    <Deterministic>false</Deterministic>
     <TargetFrameworkProfile />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/src/Extensions/BCI/Actuators/EEGProcessing/Properties/AssemblyInfo.cs
+++ b/src/Extensions/BCI/Actuators/EEGProcessing/Properties/AssemblyInfo.cs
@@ -21,16 +21,3 @@ using System.Runtime.InteropServices;
 
 // The following GUID is for the ID of the typelib if this project is exposed to COM
 [assembly: Guid("6472f0d7-ed15-4044-86e0-453593ce73f6")]
-
-// Version information for an assembly consists of the following four values:
-//
-//      Major Version
-//      Minor Version
-//      Build Number
-//      Revision
-//
-// You can specify all the values or you can default the Build and Revision Numbers
-// by using the '*' as shown below:
-// [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.0.0.0")]
-[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/src/Extensions/BCI/Actuators/EEGSettings/EEGSettings.csproj
+++ b/src/Extensions/BCI/Actuators/EEGSettings/EEGSettings.csproj
@@ -11,7 +11,7 @@
     <AssemblyName>EEGSettings</AssemblyName>
     <TargetFrameworkVersion>v4.8.1</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
-    <Deterministic>true</Deterministic>
+    <Deterministic>false</Deterministic>
     <TargetFrameworkProfile />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/src/Extensions/BCI/Actuators/EEGSettings/Properties/AssemblyInfo.cs
+++ b/src/Extensions/BCI/Actuators/EEGSettings/Properties/AssemblyInfo.cs
@@ -21,16 +21,3 @@ using System.Runtime.InteropServices;
 
 // The following GUID is for the ID of the typelib if this project is exposed to COM
 [assembly: Guid("5748f997-aca2-43a6-ab9f-f879af604080")]
-
-// Version information for an assembly consists of the following four values:
-//
-//      Major Version
-//      Minor Version
-//      Build Number
-//      Revision
-//
-// You can specify all the values or you can default the Build and Revision Numbers
-// by using the '*' as shown below:
-// [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.0.0.0")]
-[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/src/Extensions/BCI/Actuators/EEGUtilities/EEGUtils.csproj
+++ b/src/Extensions/BCI/Actuators/EEGUtilities/EEGUtils.csproj
@@ -11,7 +11,7 @@
     <TargetFrameworkVersion>v4.8.1</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
-    <Deterministic>true</Deterministic>
+    <Deterministic>false</Deterministic>
     <TargetFrameworkProfile />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/src/Extensions/BCI/Actuators/EEGUtilities/Properties/AssemblyInfo.cs
+++ b/src/Extensions/BCI/Actuators/EEGUtilities/Properties/AssemblyInfo.cs
@@ -21,16 +21,3 @@ using System.Runtime.InteropServices;
 
 // The following GUID is for the ID of the typelib if this project is exposed to COM
 [assembly: Guid("6a3faa6c-4085-4460-98f6-623f726e8f18")]
-
-// Version information for an assembly consists of the following four values:
-//
-//      Major Version
-//      Minor Version
-//      Build Number
-//      Revision
-//
-// You can specify all the values or you can default the Build and Revision Numbers
-// by using the '*' as shown below:
-// [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.0.0.0")]
-[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/src/Extensions/BCI/Actuators/SensorUI/Properties/AssemblyInfo.cs
+++ b/src/Extensions/BCI/Actuators/SensorUI/Properties/AssemblyInfo.cs
@@ -20,16 +20,3 @@ using System.Runtime.InteropServices;
 
 // The following GUID is for the ID of the typelib if this project is exposed to COM
 [assembly: Guid("ec1e8088-33a6-4593-832a-bf4722806ab2")]
-
-// Version information for an assembly consists of the following four values:
-//
-//      Major Version
-//      Minor Version
-//      Build Number
-//      Revision
-//
-// You can specify all the values or you can default the Build and Revision Numbers
-// by using the '*' as shown below:
-// [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.0.0.0")]
-[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/src/Extensions/BCI/Actuators/SensorUI/SensorUI.csproj
+++ b/src/Extensions/BCI/Actuators/SensorUI/SensorUI.csproj
@@ -11,7 +11,7 @@
     <TargetFrameworkVersion>v4.8.1</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
-    <Deterministic>true</Deterministic>
+    <Deterministic>false</Deterministic>
     <TargetFrameworkProfile />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/src/Extensions/BCI/Common/AnimationSharp/AnimationSharp.csproj
+++ b/src/Extensions/BCI/Common/AnimationSharp/AnimationSharp.csproj
@@ -11,7 +11,7 @@
     <AssemblyName>AnimationSharp</AssemblyName>
     <TargetFrameworkVersion>v4.8.1</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
-    <Deterministic>true</Deterministic>
+    <Deterministic>false</Deterministic>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>

--- a/src/Extensions/BCI/Common/AnimationSharp/Properties/AssemblyInfo.cs
+++ b/src/Extensions/BCI/Common/AnimationSharp/Properties/AssemblyInfo.cs
@@ -21,16 +21,3 @@ using System.Runtime.InteropServices;
 
 // The following GUID is for the ID of the typelib if this project is exposed to COM
 [assembly: Guid("9b1d5877-a3c0-4afd-8565-3fb32ffcd753")]
-
-// Version information for an assembly consists of the following four values:
-//
-//      Major Version
-//      Minor Version
-//      Build Number
-//      Revision
-//
-// You can specify all the values or you can default the Build and Revision Numbers
-// by using the '*' as shown below:
-// [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.0.0.0")]
-[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/src/Extensions/BCI/Common/BCIControl/BCIControl.csproj
+++ b/src/Extensions/BCI/Common/BCIControl/BCIControl.csproj
@@ -11,7 +11,7 @@
     <AssemblyName>BCIControl</AssemblyName>
     <TargetFrameworkVersion>v4.8.1</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
-    <Deterministic>true</Deterministic>
+    <Deterministic>false</Deterministic>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>

--- a/src/Extensions/BCI/Common/BCIControl/Properties/AssemblyInfo.cs
+++ b/src/Extensions/BCI/Common/BCIControl/Properties/AssemblyInfo.cs
@@ -21,16 +21,3 @@ using System.Runtime.InteropServices;
 
 // The following GUID is for the ID of the typelib if this project is exposed to COM
 [assembly: Guid("ef508e55-555d-4896-99bc-92eccd00746f")]
-
-// Version information for an assembly consists of the following four values:
-//
-//      Major Version
-//      Minor Version
-//      Build Number
-//      Revision
-//
-// You can specify all the values or you can default the Build and Revision Numbers
-// by using the '*' as shown below:
-// [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.0.0.0")]
-[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/src/Extensions/BCI/Common/BCIInterfaceUtilities/BCIInterfaceUtilities.csproj
+++ b/src/Extensions/BCI/Common/BCIInterfaceUtilities/BCIInterfaceUtilities.csproj
@@ -11,7 +11,7 @@
     <AssemblyName>BCIInterfaceUtilities</AssemblyName>
     <TargetFrameworkVersion>v4.8.1</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
-    <Deterministic>true</Deterministic>
+    <Deterministic>false</Deterministic>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>

--- a/src/Extensions/BCI/Common/BCIInterfaceUtilities/Properties/AssemblyInfo.cs
+++ b/src/Extensions/BCI/Common/BCIInterfaceUtilities/Properties/AssemblyInfo.cs
@@ -21,16 +21,3 @@ using System.Runtime.InteropServices;
 
 // The following GUID is for the ID of the typelib if this project is exposed to COM
 [assembly: Guid("ff74af7d-5c3b-4e1d-a3ec-100d00128f7c")]
-
-// Version information for an assembly consists of the following four values:
-//
-//      Major Version
-//      Minor Version
-//      Build Number
-//      Revision
-//
-// You can specify all the values or you can default the Build and Revision Numbers
-// by using the '*' as shown below:
-// [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.0.0.0")]
-[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/src/Extensions/BCI/UI/en/Scanners/Properties/AssemblyInfo.cs
+++ b/src/Extensions/BCI/UI/en/Scanners/Properties/AssemblyInfo.cs
@@ -23,15 +23,3 @@ using System.Runtime.InteropServices;
 // The following GUID is for the ID of the typelib if this project is exposed to COM
 [assembly: Guid("bf18d874-1d53-424c-baa1-1bc83f2ed8cb")]
 
-// Version information for an assembly consists of the following four values:
-//
-//      Major Version
-//      Minor Version 
-//      Build Number
-//      Revision
-//
-// You can specify all the values or you can default the Build and Revision Numbers 
-// by using the '*' as shown below:
-// [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("0.9.0.0")]
-[assembly: AssemblyFileVersion("0.9.0.0")]

--- a/src/Extensions/BCI/UI/en/UserControls/Properties/AssemblyInfo.cs
+++ b/src/Extensions/BCI/UI/en/UserControls/Properties/AssemblyInfo.cs
@@ -21,16 +21,3 @@ using System.Runtime.InteropServices;
 
 // The following GUID is for the ID of the typelib if this project is exposed to COM
 [assembly: Guid("7a9b8133-b2ee-4465-852c-41ab42fd0601")]
-
-// Version information for an assembly consists of the following four values:
-//
-//      Major Version
-//      Minor Version
-//      Build Number
-//      Revision
-//
-// You can specify all the values or you can default the Build and Revision Numbers
-// by using the '*' as shown below:
-// [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.0.0.0")]
-[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/src/Extensions/BCI/UI/en/UserControls/UserControls.csproj
+++ b/src/Extensions/BCI/UI/en/UserControls/UserControls.csproj
@@ -11,7 +11,7 @@
     <AssemblyName>UserControls</AssemblyName>
     <TargetFrameworkVersion>v4.8.1</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
-    <Deterministic>true</Deterministic>
+    <Deterministic>false</Deterministic>
     <TargetFrameworkProfile />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/src/Extensions/Default/Actuators/CameraActuator/Properties/AssemblyInfo.cs
+++ b/src/Extensions/Default/Actuators/CameraActuator/Properties/AssemblyInfo.cs
@@ -21,16 +21,3 @@ using System.Runtime.InteropServices;
 
 // The following GUID is for the ID of the typelib if this project is exposed to COM
 [assembly: Guid("066cfc39-78f9-4794-bc44-2e55dff45256")]
-
-// Version information for an assembly consists of the following four values:
-//
-//      Major Version
-//      Minor Version 
-//      Build Number
-//      Revision
-//
-// You can specify all the values or you can default the Build and Revision Numbers 
-// by using the '*' as shown below:
-// [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.0.0.0")]
-[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/src/Extensions/Default/Actuators/SampleActuator/Properties/AssemblyInfo.cs
+++ b/src/Extensions/Default/Actuators/SampleActuator/Properties/AssemblyInfo.cs
@@ -21,16 +21,3 @@ using System.Runtime.InteropServices;
 
 // The following GUID is for the ID of the typelib if this project is exposed to COM
 [assembly: Guid("066cfc39-78f9-4794-bc44-2e55dff45256")]
-
-// Version information for an assembly consists of the following four values:
-//
-//      Major Version
-//      Minor Version 
-//      Build Number
-//      Revision
-//
-// You can specify all the values or you can default the Build and Revision Numbers 
-// by using the '*' as shown below:
-// [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.0.0.0")]
-[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/src/Extensions/Default/AppAgents/ACATAgent/Properties/AssemblyInfo.cs
+++ b/src/Extensions/Default/AppAgents/ACATAgent/Properties/AssemblyInfo.cs
@@ -22,16 +22,3 @@ using System.Runtime.InteropServices;
 
 // The following GUID is for the ID of the typelib if this project is exposed to COM
 [assembly: Guid("fe8b6694-ab72-4abd-99c6-9267237c8df3")]
-
-// Version information for an assembly consists of the following four values:
-//
-//      Major Version
-//      Minor Version 
-//      Build Number
-//      Revision
-//
-// You can specify all the values or you can default the Build and Revision Numbers 
-// by using the '*' as shown below:
-// [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.0.0.0")]
-[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/src/Extensions/Default/AppAgents/TalkApplicationScannerAgent/Properties/AssemblyInfo.cs
+++ b/src/Extensions/Default/AppAgents/TalkApplicationScannerAgent/Properties/AssemblyInfo.cs
@@ -22,16 +22,3 @@ using System.Runtime.InteropServices;
 
 // The following GUID is for the ID of the typelib if this project is exposed to COM
 [assembly: Guid("fe8b6694-ab72-4abd-99c6-9267237c8df3")]
-
-// Version information for an assembly consists of the following four values:
-//
-//      Major Version
-//      Minor Version 
-//      Build Number
-//      Revision
-//
-// You can specify all the values or you can default the Build and Revision Numbers 
-// by using the '*' as shown below:
-// [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.0.0.0")]
-[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/src/Extensions/Default/SpellCheckers/SpellCheck/Properties/AssemblyInfo.cs
+++ b/src/Extensions/Default/SpellCheckers/SpellCheck/Properties/AssemblyInfo.cs
@@ -22,16 +22,3 @@ using System.Runtime.InteropServices;
 
 // The following GUID is for the ID of the typelib if this project is exposed to COM
 [assembly: Guid("d2ea276b-11dd-4535-b8bb-a88925b08234")]
-
-// Version information for an assembly consists of the following four values:
-//
-//      Major Version
-//      Minor Version 
-//      Build Number
-//      Revision
-//
-// You can specify all the values or you can default the Build and Revision Numbers 
-// by using the '*' as shown below:
-// [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.0.0.0")]
-[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/src/Extensions/Default/TTSEngines/SAPIEngine/Properties/AssemblyInfo.cs
+++ b/src/Extensions/Default/TTSEngines/SAPIEngine/Properties/AssemblyInfo.cs
@@ -22,16 +22,3 @@ using System.Runtime.InteropServices;
 
 // The following GUID is for the ID of the typelib if this project is exposed to COM
 [assembly: Guid("08be95c0-ebb9-49ad-8abc-e73cf9d54286")]
-
-// Version information for an assembly consists of the following four values:
-//
-//      Major Version
-//      Minor Version 
-//      Build Number
-//      Revision
-//
-// You can specify all the values or you can default the Build and Revision Numbers 
-// by using the '*' as shown below:
-// [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.0.0.0")]
-[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/src/Extensions/Default/TTSEngines/TTSClient/Properties/AssemblyInfo.cs
+++ b/src/Extensions/Default/TTSEngines/TTSClient/Properties/AssemblyInfo.cs
@@ -21,16 +21,3 @@ using System.Runtime.InteropServices;
 
 // The following GUID is for the ID of the typelib if this project is exposed to COM
 [assembly: Guid("f0afb84f-8106-46e2-ab3b-984c4a4429ce")]
-
-// Version information for an assembly consists of the following four values:
-//
-//      Major Version
-//      Minor Version
-//      Build Number
-//      Revision
-//
-// You can specify all the values or you can default the Build and Revision Numbers
-// by using the '*' as shown below:
-// [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.0.0.0")]
-[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/src/Extensions/Default/TTSEngines/TTSClient/TTSClient.csproj
+++ b/src/Extensions/Default/TTSEngines/TTSClient/TTSClient.csproj
@@ -11,7 +11,7 @@
     <AssemblyName>TTSClient</AssemblyName>
     <TargetFrameworkVersion>v4.8.1</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
-    <Deterministic>true</Deterministic>
+    <Deterministic>false</Deterministic>
     <TargetFrameworkProfile />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/src/Extensions/Default/UI/Dialogs/Properties/AssemblyInfo.cs
+++ b/src/Extensions/Default/UI/Dialogs/Properties/AssemblyInfo.cs
@@ -21,16 +21,3 @@ using System.Runtime.InteropServices;
 
 // The following GUID is for the ID of the typelib if this project is exposed to COM
 [assembly: Guid("bf18d874-1d53-424c-baa1-1bc83f2ed8cb")]
-
-// Version information for an assembly consists of the following four values:
-//
-//      Major Version
-//      Minor Version 
-//      Build Number
-//      Revision
-//
-// You can specify all the values or you can default the Build and Revision Numbers 
-// by using the '*' as shown below:
-// [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("0.9.0.0")]
-[assembly: AssemblyFileVersion("0.9.0.0")]

--- a/src/Extensions/Default/UI/Menus/Properties/AssemblyInfo.cs
+++ b/src/Extensions/Default/UI/Menus/Properties/AssemblyInfo.cs
@@ -22,16 +22,3 @@ using System.Runtime.InteropServices;
 
 // The following GUID is for the ID of the typelib if this project is exposed to COM
 [assembly: Guid("bf18d874-1d53-424c-baa1-1bc83f2ed8cb")]
-
-// Version information for an assembly consists of the following four values:
-//
-//      Major Version
-//      Minor Version 
-//      Build Number
-//      Revision
-//
-// You can specify all the values or you can default the Build and Revision Numbers 
-// by using the '*' as shown below:
-// [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("0.9.0.0")]
-[assembly: AssemblyFileVersion("0.9.0.0")]

--- a/src/Extensions/Default/UI/Scanners/Properties/AssemblyInfo.cs
+++ b/src/Extensions/Default/UI/Scanners/Properties/AssemblyInfo.cs
@@ -22,16 +22,3 @@ using System.Runtime.InteropServices;
 
 // The following GUID is for the ID of the typelib if this project is exposed to COM
 [assembly: Guid("bf18d874-1d53-424c-baa1-1bc83f2ed8cb")]
-
-// Version information for an assembly consists of the following four values:
-//
-//      Major Version
-//      Minor Version 
-//      Build Number
-//      Revision
-//
-// You can specify all the values or you can default the Build and Revision Numbers 
-// by using the '*' as shown below:
-// [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("0.9.0.0")]
-[assembly: AssemblyFileVersion("0.9.0.0")]

--- a/src/Extensions/Default/UI/en/Scanners/Properties/AssemblyInfo.cs
+++ b/src/Extensions/Default/UI/en/Scanners/Properties/AssemblyInfo.cs
@@ -22,16 +22,3 @@ using System.Runtime.InteropServices;
 
 // The following GUID is for the ID of the typelib if this project is exposed to COM
 [assembly: Guid("bf18d874-1d53-424c-baa1-1bc83f2ed8cb")]
-
-// Version information for an assembly consists of the following four values:
-//
-//      Major Version
-//      Minor Version 
-//      Build Number
-//      Revision
-//
-// You can specify all the values or you can default the Build and Revision Numbers 
-// by using the '*' as shown below:
-// [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("0.9.0.0")]
-[assembly: AssemblyFileVersion("0.9.0.0")]

--- a/src/Extensions/Default/UI/en/UserControls/Properties/AssemblyInfo.cs
+++ b/src/Extensions/Default/UI/en/UserControls/Properties/AssemblyInfo.cs
@@ -21,16 +21,3 @@ using System.Runtime.InteropServices;
 
 // The following GUID is for the ID of the typelib if this project is exposed to COM
 [assembly: Guid("7a9b8133-b2ee-4465-852c-41ab42fd0601")]
-
-// Version information for an assembly consists of the following four values:
-//
-//      Major Version
-//      Minor Version
-//      Build Number
-//      Revision
-//
-// You can specify all the values or you can default the Build and Revision Numbers
-// by using the '*' as shown below:
-// [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.0.0.0")]
-[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/src/Extensions/Default/UI/en/UserControls/UserControls.csproj
+++ b/src/Extensions/Default/UI/en/UserControls/UserControls.csproj
@@ -11,7 +11,7 @@
     <AssemblyName>UserControls</AssemblyName>
     <TargetFrameworkVersion>v4.8.1</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
-    <Deterministic>true</Deterministic>
+    <Deterministic>false</Deterministic>
     <TargetFrameworkProfile />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/src/Extensions/Default/WordPredictors/ConvAssist/ConvAssist.csproj
+++ b/src/Extensions/Default/WordPredictors/ConvAssist/ConvAssist.csproj
@@ -11,7 +11,7 @@
     <AssemblyName>ConvAssist</AssemblyName>
     <TargetFrameworkVersion>v4.8.1</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
-    <Deterministic>true</Deterministic>
+    <Deterministic>false</Deterministic>
     <TargetFrameworkProfile />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/src/Extensions/Default/WordPredictors/ConvAssist/Properties/AssemblyInfo.cs
+++ b/src/Extensions/Default/WordPredictors/ConvAssist/Properties/AssemblyInfo.cs
@@ -21,16 +21,3 @@ using System.Runtime.InteropServices;
 
 // The following GUID is for the ID of the typelib if this project is exposed to COM
 [assembly: Guid("ae20a883-bab4-4740-a93e-7eb0c4d5a6a5")]
-
-// Version information for an assembly consists of the following four values:
-//
-//      Major Version
-//      Minor Version
-//      Build Number
-//      Revision
-//
-// You can specify all the values or you can default the Build and Revision Numbers
-// by using the '*' as shown below:
-// [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.0.0.0")]
-[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/src/Extensions/PostBuildSolution/Properties/AssemblyInfo.cs
+++ b/src/Extensions/PostBuildSolution/Properties/AssemblyInfo.cs
@@ -21,16 +21,3 @@ using System.Runtime.InteropServices;
 
 // The following GUID is for the ID of the typelib if this project is exposed to COM
 [assembly: Guid("c8b28315-126a-44c4-84d2-244440b60989")]
-
-// Version information for an assembly consists of the following four values:
-//
-//      Major Version
-//      Minor Version 
-//      Build Number
-//      Revision
-//
-// You can specify all the values or you can default the Build and Revision Numbers 
-// by using the '*' as shown below:
-// [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("3.13")]
-[assembly: AssemblyFileVersion("3.13")]

--- a/src/Libraries/ACATCore/Properties/AssemblyInfo.cs
+++ b/src/Libraries/ACATCore/Properties/AssemblyInfo.cs
@@ -1,5 +1,4 @@
 ﻿using System.Reflection;
-using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 
 // General Information about an assembly is controlled through the following 
@@ -22,17 +21,3 @@ using System.Runtime.InteropServices;
 
 // The following GUID is for the ID of the typelib if this project is exposed to COM
 [assembly: Guid("e258518e-a3bb-4b20-aac8-d36078b7b584")]
-
-// Version information for an assembly consists of the following four values:
-//
-//      Major Version
-//      Minor Version 
-//      Build Number
-//      Revision
-//
-// You can specify all the values or you can default the Bdduild and Revision Numbers 
-// by using the '*' as shown below:
-// [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("3.13")]
-[assembly: AssemblyFileVersion("3.13")]
-

--- a/src/Libraries/ACATExtension/Properties/AssemblyInfo.cs
+++ b/src/Libraries/ACATExtension/Properties/AssemblyInfo.cs
@@ -22,16 +22,3 @@ using System.Runtime.InteropServices;
 
 // The following GUID is for the ID of the typelib if this project is exposed to COM
 [assembly: Guid("f4439eaa-25ba-4d95-bdba-5552dadb9e1d")]
-
-// Version information for an assembly consists of the following four values:
-//
-//      Major Version
-//      Minor Version 
-//      Build Number
-//      Revision
-//
-// You can specify all the values or you can default the Build and Revision Numbers 
-// by using the '*' as shown below:
-// [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("3.13")]
-[assembly: AssemblyFileVersion("3.13")]


### PR DESCRIPTION
- Removed explicit versioning from AssemblyInfo.cs files in various applications and extensions, allowing for centralized version management.
- Introduced a new Directory.Build.props file to define versioning properties for the entire solution.
- Updated project files to set Deterministic property to false for better build reproducibility.
- Cleaned up unnecessary comments and code in AssemblyInfo.cs files to streamline the codebase.