### PR TITLE
Add NuGet.Config to resolve vendored packages from local directory

### DIFF
--- a/NuGet.Config
+++ b/NuGet.Config
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <packageSources>
+    <clear />
+    <add key="nuget.org" value="https://api.nuget.org/v3/index.json" />
+    <add key="local" value="src/NuGetPackages" />
+  </packageSources>
+  <packageSourceMapping>
+    <packageSource key="local">
+      <package pattern="AcatCameraNative" />
+      <package pattern="UnicornDotNet" />
+    </packageSource>
+    <packageSource key="nuget.org">
+      <package pattern="*" />
+    </packageSource>
+  </packageSourceMapping>
+</configuration>


### PR DESCRIPTION
`AcatCameraNative` and `UnicornDotNet` are shipped as .nupkg files under `src/NuGetPackages/` but no NuGet.Config pointed `dotnet restore` at that directory. This adds one with package source mapping so the vendored packages resolve locally while all other dependencies resolve from nuget.org.